### PR TITLE
MMX on RDKB

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -65,16 +65,18 @@
 # - professional sub-contract and customization services
 #
 ################################################################################
-ifeq ($(PREFIX),)
+ifeq ($(strip $(PREFIX)),)
     PREFIX := /usr
 endif
+
+LUAPATH ?= $(PREFIX)/lib/lua
 
 all:
 	echo "Nothing to compile"
 
 install:
-	install -d $(DESTDIR)$(PREFIX)/lib/lua
-	install -m 755 prplmesh-be-utils.lua $(DESTDIR)$(PREFIX)/lib/lua
+	install -d $(DESTDIR)$(LUAPATH)
+	install -m 755 prplmesh-be-utils.lua $(DESTDIR)$(LUAPATH)
 
 	install -d $(DESTDIR)$(PREFIX)/bin/mmx_be
 	install -m 755 *get*.lua $(DESTDIR)$(PREFIX)/bin/mmx_be


### PR DESCRIPTION
LUAPATH support

Some distro install Lua modules in path containing Lua version,
    i.e. /usr/lib/lua/5.1

Add support LUAPATH:
    Path for installation Lua modules
    Path is relative to $(DESTDIR)

Closes #10 