### PR TITLE
prplmesh-be: getall: Return zero-list if list of indexes empty

### DIFF
--- a/src/prplmesh_getall.lua
+++ b/src/prplmesh_getall.lua
@@ -402,11 +402,6 @@ local function get_mmx_out(path)
 
     dfs(root)
 
-    if string.len(mmx_out_str) == 0 then
-        error("Empty output string.")
-        return false
-    end
-
     local mmx = tostring(ing.ResCode.SUCCESS) .. ";" .. mmx_out_str
 
     return mmx


### PR DESCRIPTION
MMX entrypoint should remove data from the data base if list of indexes for specific instance is empty. In current implementation getall script returns error in this case and MMX entrypoint does not remove deprecated instances from the internal database and we can see the table without values in Web UI.

#14 

Signed-off-by: Vladyslav Tupikin <v.tupikin@inango-systems.com>