### PR TITLE
prpmmesh-be: Fix Ambiorix cummon methods call

### DIFF
--- a/src/prplmesh_add.lua
+++ b/src/prplmesh_add.lua
@@ -82,7 +82,7 @@ require("mmx/ing_utils")
 --]]
 local function add_object(path)
 
-    local result = call_ubus(path, "add", {})
+    local result = call_ubus(path, "_add", {})
     if not result then
         error("Failed to add: " .. tostring(path))
         return false

--- a/src/prplmesh_del.lua
+++ b/src/prplmesh_del.lua
@@ -82,7 +82,7 @@ require("mmx/ing_utils")
 --]]
 local function del_object(path)
 
-    local result = call_ubus(path, "del", {})
+    local result = call_ubus(path, "_del", {})
     if not result then
         error("Failed to add: " .. tostring(path))
         return false

--- a/src/prplmesh_get.lua
+++ b/src/prplmesh_get.lua
@@ -72,9 +72,9 @@ require("mmx/ing_utils")
 require("prplmesh-be-utils")
 
 --[[
-     Scrit accept Ambiorix object name without placeholders as 1st cmdline arg 
+     Script accept Ambiorix object name without placeholders as 1st cmdline arg
 --]]
-d = call_ubus(arg[1], "get")
+d = call_ubus(arg[1], "_get")
 if not d then
     error("Did not get object from U-Bus")
     ing.utils.exit(ing.ResCode.FAIL)

--- a/src/prplmesh_getall.lua
+++ b/src/prplmesh_getall.lua
@@ -110,7 +110,7 @@ local function get_indexes(path)
     end
 
     -- Retrieve output from list method via path from UBus
-    instance = _ubus_connection:call(path, "list", { })
+    instance = _ubus_connection:call(path, "_list", { })
     if not instance then
         error(path .. " not found in UBus")
         _ubus_connection:close()

--- a/src/prplmesh_getall.lua
+++ b/src/prplmesh_getall.lua
@@ -402,11 +402,6 @@ local function get_mmx_out(path)
 
     dfs(root)
 
-    if string.len(mmx_out_str) == 0 then
-        error("Empty output string.")
-        return false
-    end
-
     local mmx = tostring(ing.ResCode.SUCCESS) .. ";" .. mmx_out_str
 
     return mmx

--- a/src/prplmesh_set.lua
+++ b/src/prplmesh_set.lua
@@ -132,7 +132,7 @@ local function set_data(path, ap_params)
 
     local data = {parameters = ap_params}
 
-    local ret = call_ubus(path, "set", data)
+    local ret = call_ubus(path, "_set", data)
     if not ret then
         error("Failed to set data.")
         return false


### PR DESCRIPTION
The new version of Ambiorix library contains change for all cummon methods - they was renamed by adding '_' symbol, like from 'get' to '_get' and this is causing an issue with existing MMX backend for prplMesh because we are using old function names.
    
Add prefix '_' to the Ambiorix methods.
